### PR TITLE
fix: delete copyright text in the footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -29,7 +29,7 @@
                   </a>
                </li>
             </ul>
-            <p class="copyright text-muted">Copyright &copy; Vladyslav Samoilenko 2023</p>
+            <p class="copyright text-muted"></p>
          </div>
       </div>
    </div>


### PR DESCRIPTION
As this repo is under the Unlicense license there cannot be any copyright text inside the application. Hence the deletion of copyright at the footer.